### PR TITLE
receiver tweaks

### DIFF
--- a/app/src/main/java/no/birkett/quietshare/MainActivity.java
+++ b/app/src/main/java/no/birkett/quietshare/MainActivity.java
@@ -33,7 +33,7 @@ public class MainActivity extends AppCompatActivity {
     private Spinner profileSpinner;
     private ArrayAdapter<String> spinnerArrayAdapter;
     private TextView receiveStatus;
-    
+
     private static final int MY_PERMISSIONS_REQUEST_RECORD_AUDIO = 1;
 
     @Override
@@ -82,7 +82,6 @@ public class MainActivity extends AppCompatActivity {
         try {
             transmitterConfig = new FrameTransmitterConfig(
                     this,getProfile());
-
             transmitter = new FrameTransmitter(transmitterConfig);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -122,8 +121,6 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void receive() {
-        receiver.setBlocking(5, 0);
-
         byte[] buf = new byte[1024];
         long recvLen = 0;
         try {
@@ -190,7 +187,15 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 transmitter = null;
+                if (receiver != null) {
+                    receiver.close();
+                }
                 receiver = null;
+                if (hasRecordAudioPersmission()) {
+                    setupReceiver();
+                } else {
+                    requestPermission();
+                };
             }
 
             @Override
@@ -206,4 +211,4 @@ public class MainActivity extends AppCompatActivity {
         String profile = spinnerArrayAdapter.getItem(profileSpinner.getSelectedItemPosition());
         return profile;
     }
- }
+}


### PR DESCRIPTION
Hey Alex,

I like the app :)

I made a few small tweaks to help debug it. In particular, we do a nonblocking read from the receiver. The receiver has a fairly large queue that can hold many frames and so going to nonblocking means we can quickly check if something is there and fail right away if not. This has made things a little easier to test, in my experience.

The other key thing here is closing the old receiver when we're done. Having multiple receivers open at once will give us suboptimal performance.

Using this on my LG G2 with the sim running on my laptop I've had some success at 30cm and 50cm with various profiles. Surprisingly, the ultrasonic ones seem to do best. I will continue investigating this later, it is hard to guess at what's going on but the `audible-7k` profiles seem to fare the worst. Even with the phone oriented somewhat away from the laptop the ultrasonic profiles seem to do pretty well although still not at the success rate I'd like to see.

I also boosted the gain on a lot of the profiles and pushed that to the Quiet repo. I'm not sure if all Android phones are low volume but on my G2 many of these profiles were running quieter than they should have been.
